### PR TITLE
fix RxTypeAdapter read throw on flutter-web

### DIFF
--- a/Flutter/json_to_dart/lib/models/config.dart
+++ b/Flutter/json_to_dart/lib/models/config.dart
@@ -96,7 +96,7 @@ class RxTypeAdapter<T> extends TypeAdapter<Rx<T>> {
           as Rx<T>;
     } else if (PropertyNameSortingType.none is T) {
       return PropertyNameSortingType.values[reader.readInt()].obs as Rx<T>;
-    } else if (T.toString() == 'Locale') {
+    } else if (T == Locale) {
       final Map<String, dynamic> map =
           jsonDecode(reader.readString()) as Map<String, dynamic>;
       return Locale.fromSubtags(

--- a/Flutter/json_to_dart/lib/models/config.dart
+++ b/Flutter/json_to_dart/lib/models/config.dart
@@ -6,6 +6,8 @@ import 'package:json_to_dart/utils/enums.dart';
 
 part 'config.g.dart';
 
+const Locale _emptyLocale = Locale('_');
+
 /// flutter packages pub run build_runner build --delete-conflicting-outputs
 @HiveType(typeId: TypeIds.appSetting)
 class ConfigSetting extends Setting<ConfigSetting> {
@@ -96,7 +98,7 @@ class RxTypeAdapter<T> extends TypeAdapter<Rx<T>> {
           as Rx<T>;
     } else if (PropertyNameSortingType.none is T) {
       return PropertyNameSortingType.values[reader.readInt()].obs as Rx<T>;
-    } else if (T == Locale) {
+    } else if (_emptyLocale is T) {
       final Map<String, dynamic> map =
           jsonDecode(reader.readString()) as Map<String, dynamic>;
       return Locale.fromSubtags(


### PR DESCRIPTION
由于flutter-web中dart编译成js后 Type会被混淆 使用`T.toString() == 'Locale'`进行判断并不适用于flutter-web(然后抛出异常导致在web端刷新网页后无法进入页面)